### PR TITLE
[RHMAP-5133] update mongodb initiator

### DIFF
--- a/2.4/root/usr/bin/run-mongod
+++ b/2.4/root/usr/bin/run-mongod
@@ -45,9 +45,16 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_remove
-  fi
+  # NOTE: The `endpoints` function in `common.sh` used to return ephemeral pod
+  # IPs, but now we have it return a fixed list of host names. Since the list of
+  # host names is static, we do not need nor want to add/remove new members to the
+  # replica set configuration as part of a pod lifecycle, therefore we comment out
+  # the code below.
+
+  # if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
+  #   mongo_remove
+  # fi
+
   echo "=> Shutting down MongoDB server ..."
   if [ -f "${MONGODB_PID_FILE}" ]; then
     kill -2 $(cat ${MONGODB_PID_FILE})

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -40,12 +40,12 @@ function cache_container_addr() {
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
 function wait_for_mongo_up() {
-  _wait_for_mongo 1
+  _wait_for_mongo 1 "$@"
 }
 
 # wait_for_mongo_down waits until the mongo server is down
 function wait_for_mongo_down() {
-  _wait_for_mongo 0
+  _wait_for_mongo 0 "$@"
 }
 
 # wait_for_mongo waits until the mongo server is up/down

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -73,12 +73,17 @@ function _wait_for_mongo() {
   return 1
 }
 
-# endpoints returns list of IP addresses with other instances of MongoDB
-# To get list of endpoints, you need to have headless Service named 'mongodb'.
-# NOTE: This won't work with standalone Docker container.
+# endpoints returns a list of hosts to be part of a replica set. Host names are
+# generated from MONGODB_SERVICE_NAME, appending a suffix based on the number of
+# replicas defined in MONGODB_INITIAL_REPLICA_COUNT. For each host name, there
+# should be a service with the same name, so that the name points to a valid DNS
+# entry. Example output, where MONGODB_SERVICE_NAME=mongodb and
+# MONGODB_INITIAL_REPLICA_COUNT=3:
+# mongodb-1
+# mongodb-2
+# mongodb-3
 function endpoints() {
-  service_name=${MONGODB_SERVICE_NAME:-mongodb}
-  dig ${service_name} A +search +short 2>/dev/null
+  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -127,9 +127,9 @@ function mongo_primary_member_addr() {
     while read mongo_node; do
       cmd_output="$(mongo admin -u admin -p "$MONGODB_ADMIN_PASSWORD" --host "$mongo_node:$CONTAINER_PORT" --eval 'print(rs.isMaster().primary)' --quiet || true)"
 
-      # Trying to find IP:PORT in output and filter out error message because mongo prints it to stdout
-      ip_and_port_regexp='[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+:[0-9]\+'
-      if addr="$(echo "$cmd_output" | grep -x "$ip_and_port_regexp")"; then
+      # Trying to find HOST:PORT in output and filter out error message because mongo prints it to stdout
+      host_and_port_regexp='[^:]\+:[0-9]\+'
+      if addr="$(echo "$cmd_output" | grep -x "$host_and_port_regexp")"; then
         echo -n "$addr"
         exit 0
       fi

--- a/2.4/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
@@ -11,6 +11,13 @@ source  ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 echo "=> Waiting for local MongoDB to accept connections ..."
 wait_for_mongo_up
-set -x
-# Add the current container to the replSet
-mongo_add
+
+# NOTE: The `endpoints` function in `common.sh` used to return ephemeral pod
+# IPs, but now we have it return a fixed list of host names. Since the list of
+# host names is static, we do not need nor want to add/remove new members to the
+# replica set configuration as part of a pod lifecycle, therefore we comment out
+# the code below.
+
+# set-x
+# # Add the current container to the replSet
+# mongo_add

--- a/2.6/root/usr/bin/run-mongod
+++ b/2.6/root/usr/bin/run-mongod
@@ -41,9 +41,16 @@ function unset_env_vars() {
 }
 
 function cleanup() {
-  if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
-    mongo_remove
-  fi
+  # NOTE: The `endpoints` function in `common.sh` used to return ephemeral pod
+  # IPs, but now we have it return a fixed list of host names. Since the list of
+  # host names is static, we do not need nor want to add/remove new members to the
+  # replica set configuration as part of a pod lifecycle, therefore we comment out
+  # the code below.
+
+  # if [ -n "${MONGODB_REPLICA_NAME-}" ]; then
+  #   mongo_remove
+  # fi
+
   echo "=> Shutting down MongoDB server ..."
   if [ -f "${MONGODB_PID_FILE}" ]; then
     kill -2 $(cat ${MONGODB_PID_FILE})

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -40,12 +40,12 @@ function cache_container_addr() {
 
 # wait_for_mongo_up waits until the mongo server accepts incomming connections
 function wait_for_mongo_up() {
-  _wait_for_mongo 1
+  _wait_for_mongo 1 "$@"
 }
 
 # wait_for_mongo_down waits until the mongo server is down
 function wait_for_mongo_down() {
-  _wait_for_mongo 0
+  _wait_for_mongo 0 "$@"
 }
 
 # wait_for_mongo waits until the mongo server is up/down

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -73,12 +73,17 @@ function _wait_for_mongo() {
   return 1
 }
 
-# endpoints returns list of IP addresses with other instances of MongoDB
-# To get list of endpoints, you need to have headless Service named 'mongodb'.
-# NOTE: This won't work with standalone Docker container.
+# endpoints returns a list of hosts to be part of a replica set. Host names are
+# generated from MONGODB_SERVICE_NAME, appending a suffix based on the number of
+# replicas defined in MONGODB_INITIAL_REPLICA_COUNT. For each host name, there
+# should be a service with the same name, so that the name points to a valid DNS
+# entry. Example output, where MONGODB_SERVICE_NAME=mongodb and
+# MONGODB_INITIAL_REPLICA_COUNT=3:
+# mongodb-1
+# mongodb-2
+# mongodb-3
 function endpoints() {
-  service_name=${MONGODB_SERVICE_NAME:-mongodb}
-  dig ${service_name} A +search +short 2>/dev/null
+  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -127,9 +127,9 @@ function mongo_primary_member_addr() {
     while read mongo_node; do
       cmd_output="$(mongo admin -u admin -p "$MONGODB_ADMIN_PASSWORD" --host "$mongo_node:$CONTAINER_PORT" --eval 'print(rs.isMaster().primary)' --quiet || true)"
 
-      # Trying to find IP:PORT in output and filter out error message because mongo prints it to stdout
-      ip_and_port_regexp='[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+:[0-9]\+'
-      if addr="$(echo "$cmd_output" | grep -x "$ip_and_port_regexp")"; then
+      # Trying to find HOST:PORT in output and filter out error message because mongo prints it to stdout
+      host_and_port_regexp='[^:]\+:[0-9]\+'
+      if addr="$(echo "$cmd_output" | grep -x "$host_and_port_regexp")"; then
         echo -n "$addr"
         exit 0
       fi

--- a/2.6/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/replica_supervisor.sh
@@ -11,6 +11,13 @@ source  ${CONTAINER_SCRIPTS_PATH}/common.sh
 
 echo "=> Waiting for local MongoDB to accept connections ..."
 wait_for_mongo_up
-set -x
-# Add the current container to the replSet
-mongo_add
+
+# NOTE: The `endpoints` function in `common.sh` used to return ephemeral pod
+# IPs, but now we have it return a fixed list of host names. Since the list of
+# host names is static, we do not need nor want to add/remove new members to the
+# replica set configuration as part of a pod lifecycle, therefore we comment out
+# the code below.
+
+# set-x
+# # Add the current container to the replSet
+# mongo_add


### PR DESCRIPTION
This is still WIP, wanted to share before I go on for further changes.

@grdryn you may want to play around with this.

Known issues:

- [x] `mongo_primary_member_addr` assumes the replica set config uses IP addresses, not hostnames. It is better to use hostnames, since they will survive not only redeploys/ pod restarts, but also deploying the template in a new cluster reusing the existing PVs. This impacts `mongo_add` and `mongo_remove`
  - [x] IP of the initiator is not removed from replica set configuration (`mongo_remove` issue)
  - [x] After the replica set is initialized, restarting a pod will never bring it back to the replica set (`mongo_add` issue)

---------------------

Scenarios we need to cover (RHMAP-5134):

- [x] Restart of a node with the primary mongodb on it doesn't cause the replica set to become unstable
  After scaling down the primary to 0, causes the ellection of a new primary. The replica set seems to work with two members, a primary and a secondary. Scaling the replication controller back up to 1 replica (1 pod), observed the pod joining as a secondary.
- [x] Restart of a node with a secondary mongodb on it doesn't cause the replica set to become unstable
  After scaling down a secondary to 0, the replica set configuration was not changed. The existing primary and secondary kept their roles. Scaling the replication controller back up to 1 replica (1 pod), the replica set member re-joins successfully.
- [x] Force an election to ensure replica set recovers (delay the restart of the primary node)
- [x] After restart of all nodes the replica set recovers
  After scaling down to 0 all replication controllers, scaled `mongodb-1` back up to 1 pod. Replica set status shows it joined as secondary, other members are unreachable [OK]. Brought a second pod up, election happened and now replica set has a primary and secondary [OK]. Brought the third pod up, it joined as secondary.