### PR TITLE
Renamed MBAAS_NAMESPACE to METADATA_NAMESPACE 

### DIFF
--- a/2.4/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.4/root/usr/share/container-scripts/mongodb/common.sh
@@ -80,13 +80,13 @@ function _wait_for_mongo() {
 # entry. Example output, where:
 # MONGODB_SERVICE_NAME=mongodb
 # MONGODB_INITIAL_REPLICA_COUNT=3
-# MBAAS_NAMESPACE=3node-mbaas:
+# METADATA_NAMESPACE=3node-mbaas:
 #
 # mongodb-1.3node-mbaas
 # mongodb-2.3node-mbaas
 # mongodb-3.3node-mbaas
 function endpoints() {
-  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d.${MBAAS_NAMESPACE}\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
+  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d.${METADATA_NAMESPACE}\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/2.6/root/usr/share/container-scripts/mongodb/common.sh
+++ b/2.6/root/usr/share/container-scripts/mongodb/common.sh
@@ -80,13 +80,13 @@ function _wait_for_mongo() {
 # entry. Example output, where:
 # MONGODB_SERVICE_NAME=mongodb
 # MONGODB_INITIAL_REPLICA_COUNT=3
-# MBAAS_NAMESPACE=3node-mbaas:
+# METADATA_NAMESPACE=3node-mbaas:
 #
 # mongodb-1.3node-mbaas
 # mongodb-2.3node-mbaas
 # mongodb-3.3node-mbaas
 function endpoints() {
-  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d.${MBAAS_NAMESPACE}\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
+  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d.${METADATA_NAMESPACE}\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -80,13 +80,13 @@ function _wait_for_mongo() {
 # entry. Example output, where:
 # MONGODB_SERVICE_NAME=mongodb
 # MONGODB_INITIAL_REPLICA_COUNT=3
-# MBAAS_NAMESPACE=3node-mbaas:
+# METADATA_NAMESPACE=3node-mbaas:
 #
 # mongodb-1.3node-mbaas
 # mongodb-2.3node-mbaas
 # mongodb-3.3node-mbaas
 function endpoints() {
-  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d.${MBAAS_NAMESPACE}\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
+  printf -- "${MONGODB_SERVICE_NAME:-mongodb}-%d.${METADATA_NAMESPACE}\n" $(seq ${MONGODB_INITIAL_REPLICA_COUNT:-1})
 }
 
 # build_mongo_config builds the MongoDB replicaSet config used for the cluster

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Versions
 MongoDB versions currently provided are:
 * mongodb-2.4
 * mongodb-2.6
+* mongodb-3.2
 
 RHEL versions currently supported are:
 * RHEL7


### PR DESCRIPTION
# Motivation

The core platform will be using the same mongodb 3.2 template as the mbaas, therefore it makes sense to have a more generic namepace environment variable.

# Changes

- Changed MBAAS_NAMESPACE to METADATA_NAMESPACE for mongodb 2.4 2.6 3.2
- Small addition to the README.md file