### PR TITLE
Update for mongodb when running in standalone mode

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/setup_rhmap.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/setup_rhmap.sh
@@ -2,47 +2,81 @@
 
 function setUpMbaasDB(){
   echo "=> setting up fh-mbaas db .. ";
-  local js_command="db.getSiblingDB('${MONGODB_FHMBAAS_DATABASE}').createUser({user: '${MONGODB_FHMBAAS_USER}', pwd: '${MONGODB_FHMBAAS_PASSWORD}', roles: [ 'readWrite' ]})"
-  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+  # exit if user exists
+  local js_command="db.system.users.count({'user':'${MONGODB_FHMBAAS_USER}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> ${MONGODB_FHMBAAS_USER} user is already created. No action taken"
+  else 
+    js_command="db.getSiblingDB('${MONGODB_FHMBAAS_DATABASE}').createUser({user: '${MONGODB_FHMBAAS_USER}', pwd: '${MONGODB_FHMBAAS_PASSWORD}', roles: [ 'readWrite' ]})"
+    if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
       echo "=> Failed to create MongoDB user: ${MONGODB_FHMBAAS_USER}"
       exit 1
+    fi
   fi
 }
 
 
 function setUpReporting(){
   echo "=> setting up fh-reporting db.. ";
-  local js_command="db.getSiblingDB('${MONGODB_FHREPORTING_DATABASE}').createUser({user: '${MONGODB_FHREPORTING_USER}', pwd: '${MONGODB_FHREPORTING_PASSWORD}', roles: [ 'readWrite' ]})"
-  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+
+  # exit if user exists
+  local js_command="db.system.users.count({'user':'${MONGODB_FHREPORTING_USER}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> ${MONGODB_FHREPORTING_USER} user is already created. No action taken"
+  else
+    js_command="db.getSiblingDB('${MONGODB_FHREPORTING_DATABASE}').createUser({user: '${MONGODB_FHREPORTING_USER}', pwd: '${MONGODB_FHREPORTING_PASSWORD}', roles: [ 'readWrite' ]})"
+    if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
       echo "=> Failed to create MongoDB user: ${MONGODB_FHREPORTING_USER}"
       exit 1
+    fi
   fi
 }
 
 function setUpMetrics(){
   echo "=> setting up fh-metrics db.. ";
-  local js_command="db.getSiblingDB('${MONGODB_FHMETRICS_DATABASE}').createUser({user: '${MONGODB_FHMETRICS_USER}', pwd: '${MONGODB_FHMETRICS_PASSWORD}', roles: [ 'readWrite' ]})"
-  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+
+  # exit if user exists
+  local js_command="db.system.users.count({'user':'${MONGODB_FHMETRICS_USER}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> ${MONGODB_FHMETRICS_USER} user is already created. No action taken"
+  else
+    js_command="db.getSiblingDB('${MONGODB_FHMETRICS_DATABASE}').createUser({user: '${MONGODB_FHMETRICS_USER}', pwd: '${MONGODB_FHMETRICS_PASSWORD}', roles: [ 'readWrite' ]})"
+    if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
       echo "=> Failed to create MongoDB user: ${MONGODB_FHMETRICS_USER}"
       exit 1
+    fi
   fi
 }
 
 function setUpAAA(){
   echo "=> setting up fh-aaa db.. ";
-  local js_command="db.getSiblingDB('${MONGODB_FHAAA_DATABASE}').createUser({user: '${MONGODB_FHAAA_USER}', pwd: '${MONGODB_FHAAA_PASSWORD}', roles: [ 'readWrite' ]})"
-  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+
+  # exit if user exists
+  local js_command="db.system.users.count({'user':'${MONGODB_FHAAA_USER}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> ${MONGODB_FHAAA_USER} user is already created. No action taken"
+  else
+    js_command="db.getSiblingDB('${MONGODB_FHAAA_DATABASE}').createUser({user: '${MONGODB_FHAAA_USER}', pwd: '${MONGODB_FHAAA_PASSWORD}', roles: [ 'readWrite' ]})"
+    if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
       echo "=> Failed to create MongoDB user: ${MONGODB_FHAAA_USER}"
       exit 1
+    fi
   fi
 }
 
 function setUpSupercore(){
   echo "=> setting up fh-SUPERCORE db.. ";
-  local js_command="db.getSiblingDB('${MONGODB_FHSUPERCORE_DATABASE}').createUser({user: '${MONGODB_FHSUPERCORE_USER}', pwd: '${MONGODB_FHSUPERCORE_PASSWORD}', roles: [ 'readWrite' ]})"
-  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+
+  # exit if user exists
+  local js_command="db.system.users.count({'user':'${MONGODB_FHSUPERCORE_USER}'})"
+  if [ "$(mongo admin --quiet --eval "$js_command")" == "1" ]; then
+    echo "=> ${MONGODB_FHSUPERCORE_USER} user is already created. No action taken"
+  else
+    js_command="db.getSiblingDB('${MONGODB_FHSUPERCORE_DATABASE}').createUser({user: '${MONGODB_FHSUPERCORE_USER}', pwd: '${MONGODB_FHSUPERCORE_PASSWORD}', roles: [ 'readWrite' ]})"
+    if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
       echo "=> Failed to create MongoDB user: ${MONGODB_FHSUPERCORE_USER}"
       exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
Motivation:
When running mongodb in standalone mode for on-prem core (i.e no replicaset being used) and the current ose replica is scaled to 0 and then back to 1 or in a failure scenario where the pod is replcaced,
mongodb doesn't recognize the replicaset and goes into OTHER status (actually the member is removed as it can't resolve the dns lookup)

Modifications:
Updates to the bash scripts to ensure no error occurs when the pod is replaced (when trying to create existing users).
Also updates to the fh-openshift template to ensure the MONGODB_REPLICA_NAME is empty.

Result:
When replaced , either from scaling or failure the pod (mongodb) should not error and remain in PRIMARY status.

JIRA:
https://issues.jboss.org/browse/RHMAP-9425