### PR TITLE
Adding AWS CLI tools for 4x SaaS S3 backups

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -22,13 +22,14 @@ ENTRYPOINT ["container-entrypoint"]
 CMD ["run-mongod"]
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="bind-utils gettext iproute rsync tar rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools" && \
+    yum --enablerepo=extras install -y epel-release && \
+    INSTALL_PKGS="bind-utils gettext iproute rsync tar rh-mongodb32-mongodb rh-mongodb32 rh-mongodb32-mongo-tools python-pip" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all
+    yum clean all && \
+    pip install awscli
 
 ADD root /
-
 
 # Container setup
 RUN touch /etc/mongod.conf && \


### PR DESCRIPTION
**Summary**
For 4x SaaS we need to be able to run scheduled MongoDB backups on Openshift. As we've chosen to use S3 as the place to store these backups we need to add AWS CLI tools to the MongoDB 3.2 image to run AWS S3 CLI commands for pushing the backups.

Unfortunately it is not possible to install AWS CLI via yum so we have to use pip instead.

**Related Jira**
https://issues.jboss.org/browse/RHMAP-19209