### PR TITLE
fix(Nagios is alerting high memory utilization for the MongoDB): RHMAP-20201 -  Add 60% of the default available memory amount for tiger cache

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/common.sh
+++ b/3.2/root/usr/share/container-scripts/mongodb/common.sh
@@ -55,15 +55,15 @@ function _wait_for_mongo() {
 }
 
 function wait_for_service() {
-  for x in {1..100}; do                                                                                                                                                                                                                                                                                                    
-    test=$(dig $1 A +short +search)                                                                                                                                                                                                                                                                                 
-    if [ "$test" != "" ]; then                                                                                                                                                                                                                                                                                             
-      break                                                                                                                                                                                                                                                                                                              
-    fi                                                                                                                                                                                                                                                                                                                     
-    sleep 1; 
+  for x in {1..100}; do
+    test=$(dig $1 A +short +search)
+    if [ "$test" != "" ]; then
+      break
+    fi
+    sleep 1;
     echo "=> Waiting for $1 service"
   done
-  return 0 
+  return 0
 }
 
 # endpoints returns list of IP addresses with other instances of MongoDB
@@ -270,3 +270,8 @@ within the container or visit https://github.com/sclorgk/mongodb-container/."
 function info() {
   printf "=> [%s] %s\n" "$(date +'%a %b %d %T')" "$*"
 }
+
+## The default amount of memory allocated to the a MongoDB pod is 1Gi
+## The MONGODB_WIRED_TIGER_CACHE_SIZE defined is because of the default tiger max cache size is 1Gi which
+## will cause issues since it will use all available resource of the pod.
+export MONGODB_MAX_WIRED_TIGER_CACHE_SIZE=600M

--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -19,7 +19,9 @@ net:
 storage:
   # Directory for datafiles (defaults to /data/db/)
   dbPath: ${MONGODB_DATADIR}
-
+  wiredTiger:
+    engineConfig:
+      configString: cache_size=${MONGODB_MAX_WIRED_TIGER_CACHE_SIZE}
 
 # replication Options - Configures replication
 replication:


### PR DESCRIPTION
# JIRA
https://issues.jboss.org/browse/RHMAP-20201

# What
Add specific cache size for MongoDB tiger

# Why
*If you run mongod in a container (e.g. lxc, groups, Docker, etc.) that does not have access to all of the RAM available in a system, you must set storage.wiredTiger.engineConfig.cacheSizeGB to a value less than the amount of RAM available in the container. The exact amount depends on the other processes running in the container.*  ( PS.: Exacly text from MongoDB [doc](https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB) )

In the version `3.2` of MongoDB the tiger is added by default and it will use 1Gi which is all amount available for the pod then issues regards the memory will be faced. The tiger cache as explained above need to be < than the ammount available. 

# How
* Fixed the max amount available to the tiger cache as `60%` which is `600M`. 
* Add var in the common.sh with the fixed value since it must be used in all pods( with replicaset or not )

PS.: For 3.2 is required the workaround `configString: cache_size=${MONGODB_MAX_WIRED_TIGER_CACHE_SIZE}` for it accept values < 1Gi. See [here](https://jira.mongodb.org/browse/SERVER-22274)

# Steps to verify
The image created for this PR is `docker.io/rhmap/mongodb:centos-3.2-232f150`.

## Check the logs to see if the custom cache is applied. 

1. Update the RHMAP installation to use the image generated with this PR.
2. Deploy the MongoDB pods with this image

<img width="994" alt="screen shot 2018-07-26 at 15 23 33" src="https://user-images.githubusercontent.com/7708031/43268191-e665033a-90e7-11e8-8a04-1176103a01ae.png">

<img width="1176" alt="screen shot 2018-07-26 at 15 46 26" src="https://user-images.githubusercontent.com/7708031/43269619-1fd46e46-90eb-11e8-9b3a-78747689fa88.png">

3. Check the deploy logs. It should shows `custom option: cache_size=600M` as follows.   

<img width="1171" alt="screen shot 2018-07-26 at 15 24 50" src="https://user-images.githubusercontent.com/7708031/43268279-1c62ecea-90e8-11e8-9b9f-d9484d52fd8d.png">


**Note**: It can be checked in the [csteam2](https://csteam2.skunkhenry.com:8443/console/project/rhmap-core/browse/pods/mongodb-1-2-z8dc6?tab=logs)

## Check the Nagios of RHMAP in order to see if all is fine with this image. 

<img width="1254" alt="screen shot 2018-07-26 at 11 53 49" src="https://user-images.githubusercontent.com/7708031/43258460-ca1d48ee-90ca-11e8-972c-fbd7f977cf27.png">

**Note**: It can be checked [here](https://nagios-rhmap-core.csteam2.skunkhenry.com/)

## Check the MBaaS with this image. 

1. Deploy the MongoDB image in all pods of the MBaaS. 

<img width="1190" alt="screen shot 2018-07-26 at 15 23 23" src="https://user-images.githubusercontent.com/7708031/43268209-ef28914e-90e7-11e8-9554-c895a1c63c72.png">

2. Check the deploy logs. It should shows `custom option: cache_size=600M` as follows.   

<img width="1171" alt="screen shot 2018-07-26 at 15 24 50" src="https://user-images.githubusercontent.com/7708031/43268279-1c62ecea-90e8-11e8-9b9f-d9484d52fd8d.png">


3. After all, be deployed and running well then check the Nagios of the MBaaS. It cannot show memory allerts for the mongoDB.

<img width="1156" alt="screen shot 2018-07-26 at 15 53 17" src="https://user-images.githubusercontent.com/7708031/43270104-2c9a32c2-90ec-11e8-9058-682dbfc17c01.png">

**Note:** It can be cheked [here](https://nagios-rhmap-3-node-mbaas.csteam2.skunkhenry.com/)

## Check a cloud app which will save a large amount of data in the MongoDB. 

1. Create a Cordova HelloWorld project via RHMAP studio 
2. Go to the cloud app
3. Go to editor/lib/hello.js file and subscribe it by the following content

```javascript
var express = require('express');
var bodyParser = require('body-parser');
var cors = require('cors');
var col = 2;
var qt = 300;
var fh = require('fh-mbaas-api');

function helloRoute() {
  var hello = new express.Router();
  hello.use(cors());
  hello.use(bodyParser());


  // GET REST endpoint - query params may or may not be populated
  hello.get('/', function(req, res) {
    console.log(new Date(), 'In hello route GET / req.query=', req.query);
    var world = req.query && req.query.hello ? req.query.hello : 'World';
    for (c = 0; c < col; c++) {
      var colName = "myFirstEntity" + c;
      for (i = 0; i < qt; i++) {
        var name = "Joe" + i;
        var options = {
          "act": "create",
          "type": colName, // Entity/Collection name
          "fields": { // The structure of the entry/row data. A data is analogous to "Row" in MySql or "Documents" in MongoDB
            "firstName": name,
            "lastName": "Bloggs",
            "address1": "22 Blogger Lane",
            "address2": "Bloggsville",
            "country": "Bloggland",
            "phone": "555-123456"
          }
        };
        fh.db(options, function (err, data) {
          if (err) {
            console.error("Error " + err);
          } else {
            console.log(JSON.stringify(data));
          }
        });
      }
    }

    // see http://expressjs.com/4x/api.html#res.json
    res.json({msg: 'Hello ' + world});
  });
  // POST REST endpoint - note we use 'body-parser' middleware above to parse the request body in this route.
  // This can also be added in application.js
  // See: https://github.com/senchalabs/connect#middleware for a list of Express 4 middleware
  hello.post('/', function(req, res) {
    console.log(new Date(), 'In hello route POST / req.body=', req.body);
    var world = req.body && req.body.hello ? req.body.hello : 'World';

    // see http://expressjs.com/4x/api.html#res.json
    res.json({msg: 'Hello ' + world});
  });

  return hello;
}

module.exports = helloRoute;
```
4. Deploy this cloud app
5. Call the /hello endpoint of this app
6. Check if all will works well as expected. 
7. Check if the Nagios will create some alert. 

**Note:** The POC created and used to do this test is [here](https://rhmap.csteam2.skunkhenry.com/?#projects/fneuooehezkm3agy4px5wa2h/apps/fneuooe2tvp2cafwe6ewrwpy/details). And all worked well as expected and not alerts of high memory usage were checked. 


