### PR TITLE
Revert "Reverting to default 5 percent"

### DIFF
--- a/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
+++ b/3.2/root/usr/share/container-scripts/mongodb/mongodb.conf.template
@@ -27,4 +27,4 @@ storage:
 replication:
   # Specifies a maximum size in megabytes for the replication operation log (i.e. the oplog,
   # 5% of disk space by default)
-#  oplogSizeMB: 64
+  oplogSizeMB: 64


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21789


# What
Reverts fheng/mongodb#32


# Why
breaking change for the installer



# How
Revert fheng/mongodb#32


# Verification Steps
Run the rhmap-ansible installer and use this docker image for mongodb in core


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
